### PR TITLE
Enable/Disable dates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea

--- a/README.md
+++ b/README.md
@@ -99,6 +99,19 @@ _HINT: Use `data-title` instead of `title` if you are going to use the app in th
 
 Configure the text of buttons at the bottom of the picker.
 
+### `only-valid` attribute
+
+Disable/Enable calendar days according to type and date range specified.
+
+E.g. 
+```
+only-valid="{'after': '2016-04-09' }"
+only-valid="{'after': 'today', 'inclusive': true }"
+only-valid="{'outside': {'initial': '2016-04-09', 'final': '2016-06-15'}, 'inclusive': true }"
+```
+
+Types supported: 'after', 'before', 'between' and 'outside'. If you want to include the day specified, set 'inclusive' property as 'true'.
+
 ## Internationalization factory
 
 Simple internationalization option. Inject the `$ionicPickerI18n` factory into your code and set the localized strings.

--- a/src/picker-popup.html
+++ b/src/picker-popup.html
@@ -27,7 +27,11 @@
     </div>
     <div ng-if-end class="row calendar days" ng-repeat="y in rows">
         <div class="col" ng-repeat="x in cols">
-            <div ng-show="(cellDay = y * 7 + x - firstDay) > 0 && cellDay <= daysInMonth" ng-click="changeDay(cellDay)" class="day" ng-class="{'selected': cellDay === day, 'today': cellDay === today.day && month === today.month && year === today.year}">{{cellDay}}</div>
+            <div ng-show="(cellDay = y * 7 + x - firstDay) > 0 && cellDay <= daysInMonth"
+                 ng-click="changeDay(cellDay)" class="day"
+                 ng-class="{ 'disabled': !isEnabled(cellDay), 'selected': cellDay === day, 'today': cellDay === today.day && month === today.month && year === today.year }">
+                {{cellDay}}
+            </div>
         </div>
     </div>
 

--- a/src/picker.js
+++ b/src/picker.js
@@ -12,7 +12,8 @@ angular.module("ion-datetime-picker", ["ionic"])
                 monthStep: "=?",
                 hourStep: "=?",
                 minuteStep: "=?",
-                secondStep: "=?"
+                secondStep: "=?",
+                onlyValid: "=?"
             },
             controller: function($scope, $ionicPopup, $ionicPickerI18n, $timeout) {
                 $scope.i18n = $ionicPickerI18n;
@@ -137,8 +138,79 @@ angular.module("ion-datetime-picker", ["ionic"])
                     }
                 };
                 $scope.changeDay = function(day) {
+                    if (!$scope.isEnabled(day)) {
+                        return;
+                    }
                     $scope.day = day;
                     changeViewData();
+                };
+
+                function createDate(stringDate){
+                    var date = new Date(stringDate);
+                    var isInvalidDate = isNaN(date.getTime());
+                    if (isInvalidDate) {
+                        date = new Date();//today
+                        date.setHours(0, 0, 0, 0, 0);
+                    }
+                    return date;
+                }
+
+                $scope.isEnabled = function(day) {
+                    if (!$scope.onlyValid) {
+                        return true;
+                    }
+
+                    var currentDate = new Date($scope.year, $scope.month, day);
+
+                    if ($scope.onlyValid.after) {
+
+                        var afterDate = createDate($scope.onlyValid.after);
+
+                        if ($scope.onlyValid.inclusive) {
+                            return currentDate >= afterDate;
+                        } else {
+                            return currentDate > afterDate;
+                        }
+
+                    } else
+                    if ($scope.onlyValid.before){
+
+                        var beforeDate = createDate($scope.onlyValid.after);
+
+                        if ($scope.onlyValid.inclusive) {
+                            return currentDate <= beforeDate;
+                        } else {
+                            return currentDate < beforeDate;
+                        }
+
+                    } else
+                    if ($scope.onlyValid.between){
+
+                        var initialDate = createDate($scope.onlyValid.between.initial);
+                        var finalDate = createDate($scope.onlyValid.between.final);
+
+                        if ($scope.onlyValid.inclusive) {
+                            return currentDate >= initialDate && currentDate <= finalDate;
+                        } else {
+                            return currentDate > initialDate && currentDate < finalDate;
+                        }
+
+                    } else
+                    if ($scope.onlyValid.outside){
+
+                        var initialDate = createDate($scope.onlyValid.outside.initial);
+                        var finalDate = createDate($scope.onlyValid.outside.final);
+
+                        if ($scope.onlyValid.inclusive) {
+                            return currentDate <= initialDate || currentDate >= finalDate;
+                        } else {
+                            return currentDate < initialDate || currentDate > finalDate;
+                        }
+
+                    } else {
+                        return true;
+                    }
+
                 };
                 $scope.changed = function() {
                     changeViewData();

--- a/src/picker.scss
+++ b/src/picker.scss
@@ -22,6 +22,9 @@
                 background-color: #387ef5;
                 color: white;
             }
+            &.disabled, &.disabled:hover, &.disabled.activated {
+                background-color: #ccc;
+            }
         }
         .weekday {
             font-weight: bold;


### PR DESCRIPTION
Hi Kate! hope your're fine. At my work we're using your awesome date picker, but we require to disable or enable dates in different ways (by range or after/before certain day). According to our needs I think it will be useful to enable/disable dates by this way:

for example if we need to allow only select days after 2016-04-09, we use:
`only-valid="{'after': '2016-04-09' }"`

or if we need to disable days prior to today we use ('inclusive' will include today's date): 
`only-valid="{'after': 'today', 'inclusive': true }"`

of by range:
`only-valid="{'outside': {'initial': '2016-04-09', 'final': '2016-06-15'}, 'inclusive': true }"`

I hope my implementation is ok, any issue/mod please let me know :)